### PR TITLE
Fix blockModels loading

### DIFF
--- a/classes/Autoloader.php
+++ b/classes/Autoloader.php
@@ -96,7 +96,7 @@ final class Autoloader
                 'name' => self::BLOCK_PHP,
                 'key' => 'classname',
                 'require' => false,
-                'transform' => fn ($key) => self::pascalToKebabCase($key),
+                'transform' => fn ($key) => lcfirst($key),
                 'map' => [],
             ],
             'pageModels' => [


### PR DESCRIPTION
This fixes block models with multiple words like `ImageGridBlock` which should be registered as `imageGrid` not as `image-grid`